### PR TITLE
Fix URL statefulness on client only

### DIFF
--- a/motifstudio-web/src/app/page.tsx
+++ b/motifstudio-web/src/app/page.tsx
@@ -17,7 +17,8 @@ import { getQueryParams, updateQueryParams } from "./queryparams";
  * of the graph, the motif query, and the entities in the graph.
  */
 export default function Home() {
-    const { host_id, motif, host_name } = getQueryParams();
+    const { host_id, motif, host_name } =
+        typeof window !== "undefined" ? getQueryParams() : { host_id: "", motif: "", host_name: "" };
     const [currentGraph, setCurrentGraph] = useState<HostListing | undefined>({
         id: host_id || "",
         name: host_name || "",
@@ -27,12 +28,16 @@ export default function Home() {
 
     function setSelectedGraph(graph: HostListing) {
         setCurrentGraph(graph);
-        updateQueryParams({ host_id: graph.id, host_name: graph.name });
+        if (typeof window !== "undefined") {
+            updateQueryParams({ host_id: graph.id, host_name: graph.name });
+        }
     }
 
     function updateMotifTest(value: string) {
         setQueryText(value);
-        updateQueryParams({ motif: value });
+        if (typeof window !== "undefined") {
+            updateQueryParams({ motif: value });
+        }
     }
 
     return (


### PR DESCRIPTION
Resolves the comment in #39 (@dxenes1) where references to `window` were breaking the build.

### Explanation

Nextjs was trying to build a static render of the page, which means `window` was referenced from a node environment where it doesn't exist.

### Fix

The component is now client-rendered (using the `use client` header) and the check is performed to avoid referencing `window` during the initial static build.