### PR TITLE
Secure temporary graph uploads

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -15,16 +15,16 @@ jobs:
     ruff:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: chartboost/ruff-action@v1
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - name: Set up Python 3.10
-              uses: actions/setup-python@v2
+            - uses: actions/checkout@v4
+            - name: Set up Python 3.14
+              uses: actions/setup-python@v5
               with:
-                  python-version: "3.10"
+                  python-version: "3.14"
             - name: Install dependencies
               working-directory: server/
               run: |
@@ -41,5 +41,5 @@ jobs:
             - name: Test with pytest
               working-directory: server/
               run: |
-                  pip install pytest
+                  pip install pytest pytest-asyncio
                   pytest

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,10 +21,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - name: Set up Python 3.14
+            - name: Set up Python 3.13
               uses: actions/setup-python@v5
               with:
-                  python-version: "3.14"
+                  python-version: "3.13"
             - name: Install dependencies
               working-directory: server/
               run: |

--- a/server/requirements/dev-requirements.in
+++ b/server/requirements/dev-requirements.in
@@ -5,6 +5,7 @@ flake8-bugbear
 isort
 pre-commit
 pytest
+pytest-asyncio
 safety
 pytest-picked
 pytest-testmon

--- a/server/requirements/requirements.in
+++ b/server/requirements/requirements.in
@@ -5,4 +5,4 @@ uvicorn[standard]
 dotmotif[neo4j]
 grand-cypher
 pandas
-git+https://github.com/aplbrain/grand-cypher-io
+grand-cypher-io==0.2.0

--- a/server/src/host_provider/host_provider/temporary_graph_host_provider.py
+++ b/server/src/host_provider/host_provider/temporary_graph_host_provider.py
@@ -27,6 +27,8 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
     Files are automatically expired after 14 days and cleaned up.
     """
 
+    ACCEPTED_UPLOAD_EXTENSIONS = (".graphml.gz", ".gexf.gz", ".graphml", ".gexf", ".gml", ".csv")
+
     def __init__(self, temp_dir: Optional[str] = None, expiration_days: int = 14):
         """Initialize the provider.
 
@@ -77,11 +79,11 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
 
         return False  # Unknown temp ID
 
-    def store_file(self, file_content: bytes, original_filename: str) -> str:
-        """Store a file temporarily and return a temporary ID.
+    def store_file(self, source_path: str, original_filename: str) -> str:
+        """Move a validated upload into storage and return a temporary ID.
 
         Arguments:
-            file_content (bytes): The content of the uploaded file.
+            source_path (str): The path of the staged upload.
             original_filename (str): The original filename.
 
         Returns:
@@ -90,36 +92,38 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
         # Generate a unique ID
         temp_id = str(uuid.uuid4())
 
-        # Determine file extension from original filename
-        file_ext = Path(original_filename).suffix
-        if not file_ext:
-            # Try to determine from content or default to .graphml
-            file_ext = ".graphml"
+        lower_filename = original_filename.lower()
+        file_ext = next(
+            (extension for extension in self.ACCEPTED_UPLOAD_EXTENSIONS if lower_filename.endswith(extension)),
+            None,
+        )
+        if file_ext is None:
+            raise ValueError(
+                "Unsupported graph format. Supported formats: GraphML, GEXF, GML, CSV, GraphML.gz, and GEXF.gz"
+            )
 
         # Create the temporary file path
         temp_filename = f"{temp_id}{file_ext}"
         temp_filepath = os.path.join(self.temp_dir, temp_filename)
 
-        # Write the file
-        with open(temp_filepath, "wb") as f:
-            f.write(file_content)
-
-        # Calculate expiration time
-        created_at = time.time()
-        expires_at = created_at + self.expiration_seconds
-
-        # Store the mapping with metadata
-        file_info = TemporaryFileInfo(
-            temp_id=temp_id,
-            filepath=temp_filepath,
-            original_filename=original_filename,
-            created_at=created_at,
-            expires_at=expires_at
-        )
-        self._uploaded_files[temp_id] = file_info
-
-        # Save metadata to disk for persistence
-        self._save_metadata()
+        os.replace(source_path, temp_filepath)
+        try:
+            created_at = time.time()
+            expires_at = created_at + self.expiration_seconds
+            file_info = TemporaryFileInfo(
+                temp_id=temp_id,
+                filepath=temp_filepath,
+                original_filename=original_filename,
+                created_at=created_at,
+                expires_at=expires_at
+            )
+            self._uploaded_files[temp_id] = file_info
+            self._save_metadata()
+        except Exception:
+            self._uploaded_files.pop(temp_id, None)
+            if os.path.exists(temp_filepath):
+                os.remove(temp_filepath)
+            raise
 
         return temp_id
 

--- a/server/src/server/routers/test_uploads.py
+++ b/server/src/server/routers/test_uploads.py
@@ -1,0 +1,51 @@
+import io
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from . import uploads
+
+
+class StubCommons:
+    def __init__(self):
+        self.temporary_hosts = []
+        self.host_provider_router = StubHostProviderRouter()
+
+    def add_temporary_host(self, host):
+        self.temporary_hosts.append(host)
+
+
+class StubHostProviderRouter:
+    def __init__(self):
+        self._providers = {"TemporaryGraphHostProvider": uploads._temp_provider}
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_pickle_files():
+    upload = UploadFile(filename="malicious.gpickle", file=io.BytesIO(b"not actually a pickle"))
+
+    with pytest.raises(HTTPException) as error:
+        await uploads.upload_graph(upload, commons=StubCommons())
+
+    assert error.value.status_code == 415
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_files_over_size_limit(monkeypatch):
+    monkeypatch.setattr(uploads, "MAX_UPLOAD_BYTES", 3)
+    upload = UploadFile(filename="graph.graphml", file=io.BytesIO(b"four"))
+
+    with pytest.raises(HTTPException) as error:
+        await uploads.upload_graph(upload, commons=StubCommons())
+
+    assert error.value.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_empty_files():
+    upload = UploadFile(filename="graph.graphml", file=io.BytesIO())
+
+    with pytest.raises(HTTPException) as error:
+        await uploads.upload_graph(upload, commons=StubCommons())
+
+    assert error.value.status_code == 400

--- a/server/src/server/routers/uploads.py
+++ b/server/src/server/routers/uploads.py
@@ -2,6 +2,7 @@
 
 import datetime
 import os
+import tempfile
 from typing import Annotated, List
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
@@ -25,6 +26,8 @@ router = APIRouter(
 # Global temporary provider instance
 # This will be shared across all requests
 _temp_provider = TemporaryGraphHostProvider()
+MAX_UPLOAD_BYTES = 100 * 1024 * 1024
+UPLOAD_CHUNK_BYTES = 1024 * 1024
 
 
 @router.post("/graph", response_model=GraphUploadResponse)
@@ -35,21 +38,34 @@ async def upload_graph(
 ) -> GraphUploadResponse:
     """Upload a graph file temporarily.
 
-    Supported formats: GraphML, GEXF, GML, CSV (edgelist), and their gzipped versions.
+    Supported formats: GraphML, GEXF, GML, CSV (edgelist), GraphML.gz, and GEXF.gz.
     """
+    staged_path = None
     try:
-        # Check file extension
         if not file.filename:
             raise HTTPException(status_code=400, detail="No filename provided")
 
-        # Read file content
-        content = await file.read()
+        lower_filename = file.filename.lower()
+        if not any(lower_filename.endswith(extension) for extension in _temp_provider.ACCEPTED_UPLOAD_EXTENSIONS):
+            raise HTTPException(status_code=415, detail="Unsupported graph format")
 
-        if len(content) == 0:
+        file_size = 0
+        with tempfile.NamedTemporaryFile(delete=False, dir=_temp_provider.temp_dir) as staged_file:
+            staged_path = staged_file.name
+            while chunk := await file.read(UPLOAD_CHUNK_BYTES):
+                file_size += len(chunk)
+                if file_size > MAX_UPLOAD_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=f"Upload exceeds the {MAX_UPLOAD_BYTES // (1024 * 1024)} MB limit",
+                    )
+                staged_file.write(chunk)
+
+        if file_size == 0:
             raise HTTPException(status_code=400, detail="Empty file uploaded")
 
-        # Store the file temporarily
-        temp_id = _temp_provider.store_file(content, file.filename)
+        temp_id = _temp_provider.store_file(staged_path, file.filename)
+        staged_path = None
 
         # Generate a display name
         display_name = name or file.filename
@@ -74,19 +90,19 @@ async def upload_graph(
         return GraphUploadResponse(
             temp_id=temp_id,
             original_filename=file.filename,
-            file_size=len(content),
+            file_size=file_size,
             success=True,
             error=None
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
-        return GraphUploadResponse(
-            temp_id="",
-            original_filename=file.filename or "unknown",
-            file_size=0,
-            success=False,
-            error=str(e)
-        )
+        raise HTTPException(status_code=500, detail="Failed to store uploaded graph") from e
+    finally:
+        await file.close()
+        if staged_path and os.path.exists(staged_path):
+            os.remove(staged_path)
 
 
 @router.get("/temporary", response_model=List[TemporaryHostListing])


### PR DESCRIPTION
- [x] reject pickle and other unsupported upload formats before writing them
- [x] stream uploads to disk with a 100 MB limit instead of buffering them in memory
- [x] return proper 400, 413, 415, and 500 responses and clean up staged files on failure
- [x] run backend CI on Python 3.13 with async test support
- [x] use the published grand-cypher-io release instead of a moving Git dependency