### PR TITLE
Handle frontend API and download errors

### DIFF
--- a/motifstudio-web/src/app/GraphStats.tsx
+++ b/motifstudio-web/src/app/GraphStats.tsx
@@ -101,14 +101,20 @@ export function GraphStats({
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                Accept: format,
+                Accept: "application/octet-stream",
             },
             body: JSON.stringify({
                 host_id: graph.id,
                 format: format,
             }),
         })
-            .then((res) => res.blob())
+            .then(async (res) => {
+                if (!res.ok) {
+                    const data = await res.json().catch(() => null);
+                    throw new Error(data?.detail || `Download failed with status ${res.status}`);
+                }
+                return res.blob();
+            })
             .then((blob) => {
                 // Create a URL for the blob and create a link to download it.
                 const url = URL.createObjectURL(blob);
@@ -116,6 +122,7 @@ export function GraphStats({
                 a.href = url;
                 a.download = `${graph.name}.${format}`;
                 a.click();
+                URL.revokeObjectURL(url);
             })
             .catch((error) => {
                 console.error("Download failed:", error);

--- a/motifstudio-web/src/app/api.tsx
+++ b/motifstudio-web/src/app/api.tsx
@@ -37,7 +37,11 @@ export const neuroglancerUrlFromHostVolumetricData = (
 
 export const fetcher = async (...args: any[]) => {
     const res = await fetch(...(args as [RequestInfo, RequestInit]));
-    return res.json();
+    const data = await res.json().catch(() => null);
+    if (!res.ok) {
+        throw new Error(data?.detail || data?.error || `Request failed with status ${res.status}`);
+    }
+    return data;
 };
 
 export const bodiedFetcher = async (url: string, body: any, ...args: any[]) => {

--- a/server/src/models.py
+++ b/server/src/models.py
@@ -12,7 +12,7 @@ _MotifResultsAggregatedHostVertex = dict[_HostVertexID, dict[_MotifVertexID, int
 _MotifResultsAggregatedMotifVertex = dict[_MotifVertexID, dict[_HostVertexID, int]]
 _MotifResultsAggregatedMotifVertexAttribute = dict[_MotifVertexID, dict[str, int]]
 _AttributeType = Literal["str", "int", "float", "bool", "datetime.datetime"] | None
-_GraphFormats = Literal["graphml", "graphml.gz", "gexf", "gexf.gz"] | None
+_GraphFormats = Literal["graphml", "graphml.gz", "gexf", "gexf.gz"]
 _QueryType = Literal["dotmotif", "cypher"]
 AttributeSchema = dict[str, _AttributeType]
 HostProviderID = str
@@ -211,11 +211,8 @@ class DownloadGraphQueryRequest(_QueryRequestBase):
     """A request to download a graph from a host provider."""
 
     format: _GraphFormats = Field(
-        None,
-        description=(
-            "The format to download the graph in. If not specified, "
-            "the default format for the host provider will be used."
-        ),
+        "graphml",
+        description="The format to download the graph in.",
     )
 
 
@@ -223,11 +220,8 @@ class DownloadGraphQueryResponse(_QueryResponseBase):
     """A response to a request to download a graph from a host provider."""
 
     format: _GraphFormats = Field(
-        None,
-        description=(
-            "The format to download the graph in. If not specified, "
-            "the default format for the host provider will be used."
-        ),
+        "graphml",
+        description="The format used to encode the downloaded graph.",
     )
     graph: bytes = Field(
         ...,

--- a/server/src/server/routers/queries.py
+++ b/server/src/server/routers/queries.py
@@ -139,7 +139,8 @@ def query_graph_download(
         path = _run_graph_operation(commons, _serialize_graph, nx_graph, graph_download_query_request.format)
         return FileResponse(
             path,
-            media_type=f"application/{graph_download_query_request.format}",
+            media_type="application/octet-stream",
+            filename=f"graph.{graph_download_query_request.format}",
             background=BackgroundTask(os.unlink, path),
         )
 

--- a/server/src/server/routers/test_queries.py
+++ b/server/src/server/routers/test_queries.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 from fastapi import HTTPException
 
+from ...models import DownloadGraphQueryRequest
 from .queries import _run_graph_operation, _serialize_graph
 
 
@@ -52,3 +53,7 @@ def test_serialize_graph_writes_a_temporary_file():
         assert os.path.getsize(path) > 0
     finally:
         os.unlink(path)
+
+
+def test_graph_download_defaults_to_graphml():
+    assert DownloadGraphQueryRequest(host_id="graph").format == "graphml"


### PR DESCRIPTION
- [x] reject non-successful API responses with useful error messages
- [x] default graph downloads to GraphML and return binary media types
- [x] prevent failed downloads from being saved as graph files
- [x] release browser object URLs after downloads