### PR TITLE
Restore and expire temporary graph hosts

### DIFF
--- a/server/src/host_provider/host_provider/temporary_graph_host_provider.py
+++ b/server/src/host_provider/host_provider/temporary_graph_host_provider.py
@@ -91,6 +91,7 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
         Arguments:
             source_path (str): The path of the staged upload.
             original_filename (str): The original filename.
+            display_name (str): Optional name shown for the uploaded graph.
 
         Returns:
             str: A temporary ID that can be used to reference the file.

--- a/server/src/host_provider/host_provider/temporary_graph_host_provider.py
+++ b/server/src/host_provider/host_provider/temporary_graph_host_provider.py
@@ -19,6 +19,7 @@ class TemporaryFileInfo(NamedTuple):
     temp_id: str
     filepath: str
     original_filename: str
+    display_name: str
     created_at: float
     expires_at: float
 
@@ -84,7 +85,7 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
 
         return False  # Unknown temp ID
 
-    def store_file(self, source_path: str, original_filename: str) -> str:
+    def store_file(self, source_path: str, original_filename: str, display_name: str | None = None) -> str:
         """Move a validated upload into storage and return a temporary ID.
 
         Arguments:
@@ -120,6 +121,7 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
                     temp_id=temp_id,
                     filepath=temp_filepath,
                     original_filename=original_filename,
+                    display_name=display_name or original_filename,
                     created_at=created_at,
                     expires_at=expires_at
                 )
@@ -248,6 +250,7 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
                 continue
             result[temp_id] = {
                 "original_filename": file_info.original_filename,
+                "display_name": file_info.display_name,
                 "filepath": file_info.filepath,
                 "created_at": str(file_info.created_at),
                 "expires_at": str(file_info.expires_at)
@@ -282,6 +285,7 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
             "temp_id": temp_id,
             "filepath": file_info.filepath,
             "original_filename": file_info.original_filename,
+            "display_name": file_info.display_name,
             "filename": os.path.basename(file_info.filepath),
             "size": str(stat.st_size),
             "created_at": str(file_info.created_at),
@@ -306,6 +310,7 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
                         temp_id=temp_id,
                         filepath=file_data["filepath"],
                         original_filename=file_data["original_filename"],
+                        display_name=file_data.get("display_name", file_data["original_filename"]),
                         created_at=file_data["created_at"],
                         expires_at=file_data["expires_at"]
                     )
@@ -322,6 +327,7 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
             data[temp_id] = {
                 "filepath": file_info.filepath,
                 "original_filename": file_info.original_filename,
+                "display_name": file_info.display_name,
                 "created_at": file_info.created_at,
                 "expires_at": file_info.expires_at
             }
@@ -360,6 +366,18 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
 
         for temp_id in expired_ids:
             self.cleanup_file(temp_id)
+
+    def cleanup_expired_files(self) -> list[str]:
+        """Remove expired uploads and return their IDs."""
+        self._load_existing_files()
+        expired_ids = [
+            temp_id
+            for temp_id, file_info in self._uploaded_files.items()
+            if time.time() > file_info.expires_at
+        ]
+        for temp_id in expired_ids:
+            self.cleanup_file(temp_id)
+        return expired_ids
 
     def _cleanup_single_file(self, temp_id: str):
         """Clean up a single temporary file without saving metadata."""

--- a/server/src/host_provider/host_provider/test_temporary_graph_host_provider.py
+++ b/server/src/host_provider/host_provider/test_temporary_graph_host_provider.py
@@ -28,3 +28,12 @@ def test_metadata_replacement_always_produces_valid_json(tmp_path):
     metadata = Path(provider.metadata_file)
     assert json.loads(metadata.read_text())
     assert not list(metadata.parent.glob("metadata.*.tmp"))
+
+
+def test_display_name_survives_provider_restart(tmp_path):
+    provider = TemporaryGraphHostProvider(str(tmp_path))
+    temp_id = provider.store_file(_stage_file(tmp_path, "graph.csv"), "graph.csv", "My graph")
+
+    restarted = TemporaryGraphHostProvider(str(tmp_path))
+
+    assert restarted.get_file_info(temp_id)["display_name"] == "My graph"

--- a/server/src/server/__init__.py
+++ b/server/src/server/__init__.py
@@ -7,6 +7,8 @@ FastAPI. Requests are handled by the endpoints defined in this file.
 """
 
 import datetime
+import asyncio
+from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -17,7 +19,25 @@ from .routers import host_providers, queries, uploads
 __version__ = "0.1.0"
 
 
-app = FastAPI()
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    commons = provider_router()
+    uploads.sync_temporary_hosts(commons)
+
+    async def cleanup_expired_uploads():
+        while True:
+            await asyncio.sleep(60 * 60)
+            uploads._temp_provider.cleanup_expired_files()
+            uploads.sync_temporary_hosts(commons)
+
+    cleanup_task = asyncio.create_task(cleanup_expired_uploads())
+    try:
+        yield
+    finally:
+        cleanup_task.cancel()
+
+
+app = FastAPI(lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],

--- a/server/src/server/commons.py
+++ b/server/src/server/commons.py
@@ -190,6 +190,10 @@ class HostProviderRouterGlobalDep:
             str | None: The URI of the host, or None if it doesn't exist.
 
         """
+        from .routers.uploads import sync_temporary_hosts
+
+        sync_temporary_hosts(self)
+
         # Check public hosts first
         for host in self.all_hosts:
             if host.id == id:

--- a/server/src/server/routers/uploads.py
+++ b/server/src/server/routers/uploads.py
@@ -64,11 +64,9 @@ async def upload_graph(
         if file_size == 0:
             raise HTTPException(status_code=400, detail="Empty file uploaded")
 
-        temp_id = _temp_provider.store_file(staged_path, file.filename)
-        staged_path = None
-
-        # Generate a display name
         display_name = name or file.filename
+        temp_id = _temp_provider.store_file(staged_path, file.filename, display_name)
+        staged_path = None
 
         # Add temporary host to the router with proper HostListing
         temp_uri = f"temp://{temp_id}"
@@ -186,4 +184,21 @@ def get_temporary_graph_info(
     }
 
 
-__all__ = ["router"]
+def sync_temporary_hosts(commons: HostProviderRouterGlobalDep) -> None:
+    """Rebuild temporary host routing from durable provider metadata."""
+    commons.temporary_hosts = [
+        HostListing(
+            id=temp_id,
+            uri=f"temp://{temp_id}",
+            name=info.get("display_name", info["original_filename"]),
+            provider={"@id": "TemporaryGraphHostProvider"},
+            volumetric_data={},
+        )
+        for temp_id in _temp_provider.list_temporary_files()
+        if (info := _temp_provider.get_file_info(temp_id))
+    ]
+    if "TemporaryGraphHostProvider" not in commons.host_provider_router._providers:
+        commons.host_provider_router.add_provider("TemporaryGraphHostProvider", _temp_provider)
+
+
+__all__ = ["router", "sync_temporary_hosts"]


### PR DESCRIPTION
- [x] persist uploaded graph display names with durable metadata
- [x] rebuild temporary host routing after server restarts
- [x] refresh temporary routing when resolving graph IDs
- [x] remove expired uploads on an hourly background schedule