### PR TITLE
Validate graph uploads before registration

### DIFF
--- a/server/src/host_provider/host_provider/temporary_graph_host_provider.py
+++ b/server/src/host_provider/host_provider/temporary_graph_host_provider.py
@@ -136,6 +136,30 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
 
         return temp_id
 
+    def validate_file(self, filepath: str, original_filename: str) -> None:
+        """Parse a staged upload without registering it.
+
+        Arguments:
+            filepath (str): Path to the staged upload.
+            original_filename (str): Filename used to select the parser.
+        """
+        lower_filename = original_filename.lower()
+        extension = next(
+            (suffix for suffix in self.ACCEPTED_UPLOAD_EXTENSIONS if lower_filename.endswith(suffix)),
+            None,
+        )
+        if extension == ".csv":
+            self._read_csv_edgelist(filepath)
+            return
+        if extension is None:
+            raise ValueError("Unsupported graph format")
+        temporary_path = f"{filepath}{extension}"
+        os.replace(filepath, temporary_path)
+        try:
+            super().get_networkx_graph(temporary_path)
+        finally:
+            os.replace(temporary_path, filepath)
+
     def get_networkx_graph(self, uri: str) -> nx.Graph:
         """Return a NetworkX graph from a temporary URI.
 
@@ -224,18 +248,15 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
         Returns:
             bool: True if the file was successfully cleaned up.
         """
-        try:
-            with self._metadata_transaction():
-                if temp_id not in self._uploaded_files:
-                    return False
-                file_info = self._uploaded_files[temp_id]
-                if os.path.exists(file_info.filepath):
-                    os.remove(file_info.filepath)
-                del self._uploaded_files[temp_id]
-                self._save_metadata()
-            return True
-        except Exception:
-            return False
+        with self._metadata_transaction():
+            if temp_id not in self._uploaded_files:
+                return False
+            file_info = self._uploaded_files[temp_id]
+            if os.path.exists(file_info.filepath):
+                os.remove(file_info.filepath)
+            del self._uploaded_files[temp_id]
+            self._save_metadata()
+        return True
 
     def list_temporary_files(self) -> Dict[str, Dict[str, str]]:
         """List all temporary files.

--- a/server/src/server/routers/test_uploads.py
+++ b/server/src/server/routers/test_uploads.py
@@ -49,3 +49,15 @@ async def test_upload_rejects_empty_files():
         await uploads.upload_graph(upload, commons=StubCommons())
 
     assert error.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_invalid_graph_content():
+    upload = UploadFile(filename="graph.graphml", file=io.BytesIO(b"not graphml"))
+    commons = StubCommons()
+
+    with pytest.raises(HTTPException) as error:
+        await uploads.upload_graph(upload, commons=commons)
+
+    assert error.value.status_code == 422
+    assert commons.temporary_hosts == []

--- a/server/src/server/routers/uploads.py
+++ b/server/src/server/routers/uploads.py
@@ -65,6 +65,11 @@ async def upload_graph(
             raise HTTPException(status_code=400, detail="Empty file uploaded")
 
         display_name = name or file.filename
+        try:
+            _temp_provider.validate_file(staged_path, file.filename)
+        except Exception as error:
+            raise HTTPException(status_code=422, detail=f"Invalid graph file: {error}") from error
+
         temp_id = _temp_provider.store_file(staged_path, file.filename, display_name)
         staged_path = None
 
@@ -139,11 +144,9 @@ def cleanup_temporary_graph(
 ) -> GraphUploadCleanupResponse:
     """Clean up a temporarily uploaded graph."""
     try:
-        # Remove from temporary hosts list
-        commons.remove_temporary_host(temp_id)
-
-        # Cleanup the file
         success = _temp_provider.cleanup_file(temp_id)
+        if success:
+            commons.remove_temporary_host(temp_id)
 
         return GraphUploadCleanupResponse(
             temp_id=temp_id,
@@ -151,12 +154,8 @@ def cleanup_temporary_graph(
             error=None if success else "Failed to cleanup file"
         )
 
-    except Exception as e:
-        return GraphUploadCleanupResponse(
-            temp_id=temp_id,
-            success=False,
-            error=str(e)
-        )
+    except Exception as error:
+        raise HTTPException(status_code=500, detail="Failed to cleanup temporary graph") from error
 
 
 @router.get("/temporary/{temp_id}/info")


### PR DESCRIPTION
- [x] parse staged graph files before adding durable metadata
- [x] reject malformed uploads without creating host routes
- [x] remove host routing only after durable file cleanup succeeds
- [x] return server errors when cleanup cannot complete