### PR TITLE
Improve compressed and CSV graph ingestion

### DIFF
--- a/server/src/host_provider/host_provider/SingleFileHostProvider.py
+++ b/server/src/host_provider/host_provider/SingleFileHostProvider.py
@@ -56,4 +56,10 @@ class SingleFileGraphHostProvider(NetworkXHostProvider):
             nx.Graph: The NetworkX graph.
 
         """
-        return ACCEPTED_EXTENSIONS[uri.split(".")[-1]](uri)
+        extension = next(
+            (candidate for candidate in sorted(ACCEPTED_EXTENSIONS, key=len, reverse=True) if uri.endswith(candidate)),
+            None,
+        )
+        if extension is None:
+            raise ValueError(f"Unsupported graph file: {uri}")
+        return ACCEPTED_EXTENSIONS[extension](uri)

--- a/server/src/host_provider/host_provider/temporary_graph_host_provider.py
+++ b/server/src/host_provider/host_provider/temporary_graph_host_provider.py
@@ -211,26 +211,15 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
             if len(df.columns) < 2:
                 raise ValueError("CSV file must have at least 2 columns for source and target nodes")
 
-            # Create graph from edgelist
-            G = nx.Graph()
-
-            # Get column names
             source_col = df.columns[0]
             target_col = df.columns[1]
-
-            # Add edges
-            for _, row in df.iterrows():
-                source = row[source_col]
-                target = row[target_col]
-
-                # Add edge with any additional attributes
-                edge_attrs = {}
-                for col in df.columns[2:]:
-                    edge_attrs[col] = row[col]
-
-                G.add_edge(source, target, **edge_attrs)
-
-            return G
+            return nx.from_pandas_edgelist(
+                df,
+                source=source_col,
+                target=target_col,
+                edge_attr=list(df.columns[2:]) or None,
+                create_using=nx.Graph,
+            )
 
         except Exception as e:
             # If CSV reading fails, try as plain text edgelist

--- a/server/src/host_provider/host_provider/test_filesystem_host_provider.py
+++ b/server/src/host_provider/host_provider/test_filesystem_host_provider.py
@@ -27,3 +27,12 @@ def test_can_count_motifs():
         r = FilesystemGraphHostProvider()
         # Query the provider for the motif count.
         assert r.get_motif_count(uri, "A->B") == 12
+
+
+def test_can_read_compressed_graphml():
+    g = nx.path_graph(4)
+    with tempfile.NamedTemporaryFile(suffix=".graphml.gz") as f:
+        nx.write_graphml(g, f.name)
+        provider = FilesystemGraphHostProvider()
+
+        assert nx.is_isomorphic(g, provider.get_networkx_graph("file://" + f.name))

--- a/server/src/host_provider/host_provider/test_temporary_graph_host_provider.py
+++ b/server/src/host_provider/host_provider/test_temporary_graph_host_provider.py
@@ -37,3 +37,14 @@ def test_display_name_survives_provider_restart(tmp_path):
     restarted = TemporaryGraphHostProvider(str(tmp_path))
 
     assert restarted.get_file_info(temp_id)["display_name"] == "My graph"
+
+
+def test_csv_attributes_are_preserved(tmp_path):
+    provider = TemporaryGraphHostProvider(str(tmp_path))
+    path = tmp_path / "attributes.csv"
+    path.write_text("source,target,weight,label\na,b,2,edge\n")
+
+    graph = provider._read_csv_edgelist(str(path))
+
+    assert graph.edges["a", "b"]["weight"] == 2
+    assert graph.edges["a", "b"]["label"] == "edge"


### PR DESCRIPTION
- [x] select graph readers using the longest matching file suffix
- [x] load compressed GraphML and GEXF files correctly
- [x] build CSV graphs without Python row iteration
- [x] preserve CSV edge attributes during vectorized conversion