### PR TITLE
Handle query result edge cases

### DIFF
--- a/motifstudio-web/src/app/GraphStats.tsx
+++ b/motifstudio-web/src/app/GraphStats.tsx
@@ -131,7 +131,9 @@ export function GraphStats({
                             <b>Density</b>
                         </div>
                         <div className="w-1/2">
-                            {(properties.edge_count / Math.pow(properties.vertex_count, 2)).toFixed(6)}
+                            {properties.vertex_count === 0
+                                ? "0.000000"
+                                : (properties.edge_count / Math.pow(properties.vertex_count, 2)).toFixed(6)}
                         </div>
                     </div>
                 </div>

--- a/motifstudio-web/src/app/ResultsFetcher.tsx
+++ b/motifstudio-web/src/app/ResultsFetcher.tsx
@@ -9,10 +9,12 @@ export function ResultsFetcher({
     graph,
     query,
     queryType,
+    limit,
 }: {
     graph: HostListing | null;
     query: string;
     queryType: "dotmotif" | "cypher";
+    limit?: number;
 }) {
     const debouncedQuery = useDebounce(query, 500);
     const [controller] = useState(() => new AbortController());
@@ -25,13 +27,14 @@ export function ResultsFetcher({
         data: queryData,
         error: queryError,
         isLoading: queryIsLoading,
-    } = useSWR([`${BASE_URL}/queries/motifs`, graph?.id, debouncedQuery, queryType], () =>
+    } = useSWR([`${BASE_URL}/queries/motifs`, graph?.id, debouncedQuery, queryType, limit], () =>
         bodiedFetcher(
             `${BASE_URL}/queries/motifs`,
             {
                 host_id: graph?.id,
                 query: debouncedQuery,
                 query_type: queryType,
+                limit,
             },
             { signal: controller.signal }
         )
@@ -71,10 +74,7 @@ export function ResultsFetcher({
         return <div className="text-red-500 p-4">{errorText}</div>;
     }
 
-    let motifCountString = "";
-    if (queryData?.motif_count) {
-        motifCountString = queryData.motif_count.toLocaleString();
-    }
+    const motifCountString = queryData?.motif_count?.toLocaleString();
 
     /**
      * Download the results in the requested format.
@@ -138,7 +138,7 @@ export function ResultsFetcher({
                 <div className="w-full">
                     <b>Result Count</b>
                 </div>
-                <div className="w-full">{motifCountString || "Error"}</div>
+                <div className="w-full">{motifCountString ?? "Error"}</div>
             </div>
             <div className="flex flex-row gap-2 items-center">
                 <div className="w-full">

--- a/motifstudio-web/src/app/ResultsWrapper.tsx
+++ b/motifstudio-web/src/app/ResultsWrapper.tsx
@@ -15,6 +15,7 @@ export function ResultsWrapper({
 }) {
     // Trigger results fetch on button click
     const [trigger, setTrigger] = useState(false);
+    const [limit, setLimit] = useState(1000);
     // When graph or query changes, reset trigger
     useEffect(() => {
         setTrigger(false);
@@ -23,12 +24,25 @@ export function ResultsWrapper({
     return (
         <div className="flex flex-col gap-2 w-full h-full p-4 bg-white rounded-lg shadow-lg dark:bg-gray-800">
             {!trigger ? (
-                <button
-                    className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-                    onClick={() => setTrigger(!trigger)}
-                >
-                    Run Query
-                </button>
+                <div className="flex items-end gap-3">
+                    <label className="flex flex-col gap-1 text-sm font-medium dark:text-gray-200">
+                        Result limit
+                        <input
+                            type="number"
+                            min={1}
+                            max={10000}
+                            value={limit}
+                            onChange={(event) => setLimit(Math.min(10000, Math.max(1, Number(event.target.value) || 1)))}
+                            className="w-32 rounded border border-gray-300 px-3 py-2 dark:bg-gray-900 dark:border-gray-600"
+                        />
+                    </label>
+                    <button
+                        className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+                        onClick={() => setTrigger(true)}
+                    >
+                        Run Query
+                    </button>
+                </div>
             ) : null}
             {trigger ? (
                 <ResultsFetcher
@@ -36,6 +50,7 @@ export function ResultsWrapper({
                     graph={graph}
                     query={query}
                     queryType={queryType}
+                    limit={limit}
                 />
             ) : null}
         </div>

--- a/server/src/aggregators/sample.py
+++ b/server/src/aggregators/sample.py
@@ -29,7 +29,7 @@ class MotifResultsSampleAggregator(MotifResultsAggregator):
                 results.
 
         """
-        return random.sample(results, self._limit)
+        return random.sample(results, min(self._limit, len(results)))
 
 
 __all__ = ["MotifResultsSampleAggregator"]

--- a/server/src/aggregators/test_sample.py
+++ b/server/src/aggregators/test_sample.py
@@ -1,0 +1,7 @@
+from .sample import MotifResultsSampleAggregator
+
+
+def test_sample_limit_larger_than_results_returns_all_results():
+    results = [{"A": "a"}, {"A": "b"}]
+
+    assert sorted(MotifResultsSampleAggregator(limit=10).aggregate(results), key=lambda result: result["A"]) == results

--- a/server/src/host_provider/host_provider/host_provider.py
+++ b/server/src/host_provider/host_provider/host_provider.py
@@ -97,7 +97,13 @@ class HostProvider(Protocol):
         """
         ...
 
-    def get_motifs(self, uri: str, motif_string: str, aggregation_type: str | None = None) -> PossibleMotifResultTypes:
+    def get_motifs(
+        self,
+        uri: str,
+        motif_string: str,
+        aggregation_type: str | None = None,
+        limit: int | None = None,
+    ) -> tuple[int, PossibleMotifResultTypes]:
         """Get the motifs in the graph.
 
         Optionally, transform the results using an aggregation from the
@@ -254,7 +260,13 @@ class NetworkXHostProvider(HostProvider):
         executor = GrandIsoExecutor(graph=graph)
         return executor.count(motif)
 
-    def get_motifs(self, uri: str, motif_string: str, aggregation_type: str | None = None) -> PossibleMotifResultTypes:
+    def get_motifs(
+        self,
+        uri: str,
+        motif_string: str,
+        aggregation_type: str | None = None,
+        limit: int | None = None,
+    ) -> tuple[int, PossibleMotifResultTypes]:
         """Return the motifs in the graph.
 
         Optionally, transform the results using an aggregation from the
@@ -294,7 +306,8 @@ class NetworkXHostProvider(HostProvider):
         # The only "special" argument is limit. If we decide to have other
         # pre-processing arguments in the future, we will likely want to handle
         # them more explicitly.
-        results = executor.find(motif, limit=parsed_agg_args.get("limit", None))
+        results = list(executor.find(motif))
+        count = len(results)
         try:
             results = [
                 {k: {
@@ -306,7 +319,10 @@ class NetworkXHostProvider(HostProvider):
             ]
         except AttributeError:
             print(f"Could not enrich motif result dict for host {uri}")
-        return aggregator(**parsed_agg_args).aggregate(results)
+        results = aggregator(**parsed_agg_args).aggregate(results)
+        if limit is not None and isinstance(results, list):
+            results = results[:limit]
+        return count, results
 
 
 __all__ = [

--- a/server/src/host_provider/host_provider/host_provider.py
+++ b/server/src/host_provider/host_provider/host_provider.py
@@ -113,9 +113,11 @@ class HostProvider(Protocol):
             uri (str): The URI of the host.
             motif_string (str): The motif to query.
             aggregation_type (str): The aggregation to use.
+            limit (int): The maximum number of result rows to return.
 
         Returns:
-            PossibleMotifResultTypes: The results, optionally aggregated.
+            tuple[int, PossibleMotifResultTypes]: The total match count and the
+                results, optionally limited or aggregated.
 
         """
         ...
@@ -276,9 +278,11 @@ class NetworkXHostProvider(HostProvider):
             uri (str): The URI of the host.
             motif_string (str): The motif to query.
             aggregation_type (str): The aggregation to use.
+            limit (int): The maximum number of result rows to return.
 
         Returns:
-            PossibleMotifResultTypes: The results, optionally aggregated.
+            tuple[int, PossibleMotifResultTypes]: The total match count and the
+                results, optionally limited or aggregated.
 
         """
         # Try to parse the motif string, and raise a ValueError if it's invalid

--- a/server/src/host_provider/host_provider/temporary_graph_host_provider.py
+++ b/server/src/host_provider/host_provider/temporary_graph_host_provider.py
@@ -260,6 +260,7 @@ class TemporaryGraphHostProvider(SingleFileGraphHostProvider):
             if time.time() > file_info.expires_at:
                 continue
             result[temp_id] = {
+                "temp_id": temp_id,
                 "original_filename": file_info.original_filename,
                 "display_name": file_info.display_name,
                 "filepath": file_info.filepath,

--- a/server/src/host_provider/host_provider/test_temporary_graph_host_provider.py
+++ b/server/src/host_provider/host_provider/test_temporary_graph_host_provider.py
@@ -48,3 +48,10 @@ def test_csv_attributes_are_preserved(tmp_path):
 
     assert graph.edges["a", "b"]["weight"] == 2
     assert graph.edges["a", "b"]["label"] == "edge"
+
+
+def test_list_metadata_includes_temporary_id(tmp_path):
+    provider = TemporaryGraphHostProvider(str(tmp_path))
+    temp_id = provider.store_file(_stage_file(tmp_path, "graph.csv"), "graph.csv")
+
+    assert provider.list_temporary_files()[temp_id]["temp_id"] == temp_id

--- a/server/src/models.py
+++ b/server/src/models.py
@@ -200,6 +200,12 @@ class MotifQueryRequest(BaseModel):
         None,
         description="The type of aggregation to perform on the results",
     )
+    limit: int | None = Field(
+        None,
+        ge=1,
+        le=10000,
+        description="Maximum number of result rows to return",
+    )
 
 
 class MotifQueryResponse(_QueryResponseBase):

--- a/server/src/server/routers/queries.py
+++ b/server/src/server/routers/queries.py
@@ -568,6 +568,8 @@ async def query_motifs(
                             formatted_results.append(result_row)
 
                 count = len(formatted_results)
+                if motif_query_request.limit is not None:
+                    formatted_results = formatted_results[:motif_query_request.limit]
 
                 return MotifQueryResponse(
                     query=motif_query_request.query,
@@ -588,16 +590,18 @@ async def query_motifs(
         else:
             # Default to DotMotif for backward compatibility
             motif = Motif(motif_query_request.query)
-            results = await asyncio.to_thread(
+            count, results = await asyncio.to_thread(
                 run_with_limits,
                 provider.get_motifs,
                 (uri, motif_query_request.query),
-                {"aggregation_type": motif_query_request.aggregation_type},
+                {
+                    "aggregation_type": motif_query_request.aggregation_type,
+                    "limit": motif_query_request.limit,
+                },
                 ram_limit,
                 timeout,
                 cancel_event,
             )
-            count = len(results)
             return MotifQueryResponse(
                 query=motif_query_request.query,
                 query_type=motif_query_request.query_type,

--- a/server/src/server/routers/test_queries.py
+++ b/server/src/server/routers/test_queries.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 from fastapi import HTTPException
 
-from ...models import DownloadGraphQueryRequest
+from ...models import DownloadGraphQueryRequest, MotifQueryRequest
 from .queries import _run_graph_operation, _serialize_graph
 from ...host_provider.host_provider.host_provider import NetworkXHostProvider
 
@@ -78,3 +78,33 @@ def test_graph_properties_loads_graph_once():
         "vertex_attributes": {"kind": "str"},
         "edge_attributes": {"weight": "int"},
     }
+
+
+def test_motif_query_limit_is_bounded():
+    assert MotifQueryRequest(host_id="graph", query="A", limit=10).limit == 10
+    with pytest.raises(ValueError):
+        MotifQueryRequest(host_id="graph", query="A", limit=10001)
+
+
+def test_motif_limit_preserves_total_count():
+    import networkx as nx
+
+    provider = NetworkXHostProvider()
+    provider.get_networkx_graph = Mock(return_value=nx.path_graph(4))
+
+    count, results = provider.get_motifs("graph", "A -- B", limit=2)
+
+    assert count == 6
+    assert len(results) == 2
+
+
+def test_motif_aggregation_preserves_match_count():
+    import networkx as nx
+
+    provider = NetworkXHostProvider()
+    provider.get_networkx_graph = Mock(return_value=nx.path_graph(4))
+
+    count, results = provider.get_motifs("graph", "A -- B", aggregation_type="sample | {\"limit\": 2}")
+
+    assert count == 6
+    assert len(results) == 2


### PR DESCRIPTION
- Add a validated optional query result limit to the API and UI
- Preserve total motif counts when limiting or aggregating returned results
- Handle sample sizes larger than available results
- Display zero results and empty-graph density correctly
- Include temporary IDs consistently in upload metadata

Closes #55