### PR TITLE
Configure frontend API routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+Set `NEXT_PUBLIC_API_BASE_URL` when building the static frontend to target a different API. If unset, the production API is used. Docker Compose builds the frontend against the local backend exposed at `http://localhost:7082`:
+
+```bash
+docker compose up --build
+```
+
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,10 @@ version: '3.8'
 services:
   motifstudio-web:
     # Lives at ./motifstudio-web/Dockerfile
-    build: ./motifstudio-web
+    build:
+      context: ./motifstudio-web
+      args:
+        NEXT_PUBLIC_API_BASE_URL: http://localhost:7082
     ports:
       - "7080:80"
   motifstudio-server:
@@ -12,6 +15,5 @@ services:
     build: ./server
     ports:
       - "7082:8000"
-
 
 

--- a/motifstudio-web/Dockerfile
+++ b/motifstudio-web/Dockerfile
@@ -5,6 +5,9 @@
 # Build environment
 FROM node:22-alpine as build
 
+ARG NEXT_PUBLIC_API_BASE_URL=https://api.motifstudio.bossdb.org
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+
 # Set working directory
 WORKDIR /app
 
@@ -12,7 +15,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm install
+RUN npm ci
 
 # Copy source code
 COPY . .

--- a/motifstudio-web/src/app/api.tsx
+++ b/motifstudio-web/src/app/api.tsx
@@ -1,8 +1,7 @@
-// Base URL based on dev status:
-export const BASE_URL =
-    process.env.NODE_ENV === "development" ? "http://localhost:8000" : "https://api.motifstudio.bossdb.org";
-
-// export const BASE_URL = "https://api.motifstudio.bossdb.org";
+export const BASE_URL = (process.env.NEXT_PUBLIC_API_BASE_URL || "https://api.motifstudio.bossdb.org").replace(
+    /\/$/,
+    ""
+);
 
 export const neuroglancerUrlFromHostVolumetricData = (
     segmentationUri: string,


### PR DESCRIPTION
- Configure the static frontend with NEXT_PUBLIC_API_BASE_URL
- Preserve the hosted production API as the default
- Build Docker Compose against the local backend on port 7082
- Use reproducible npm installs in the frontend image
- Document custom and Compose builds