### PR TITLE
Synchronize frontend state

### DIFF
--- a/motifstudio-web/src/app/Appbar.tsx
+++ b/motifstudio-web/src/app/Appbar.tsx
@@ -7,17 +7,18 @@ import { HelpMenu } from "./components/HelpMenu";
 
 interface AppbarProps {
     queryText: string;
+    queryType: "dotmotif" | "cypher";
     currentGraph?: HostListing;
     onLoad: (data: { queryText: string; graph?: HostListing }) => void;
     onInsertPrimitive: (dotmotif: string) => void;
 }
 
-export function Appbar({ queryText, currentGraph, onLoad, onInsertPrimitive }: AppbarProps) {
+export function Appbar({ queryText, queryType, currentGraph, onLoad, onInsertPrimitive }: AppbarProps) {
     return (
         <div className="w-full items-center justify-between font-mono text-sm lg:flex p-4">
             <div className="flex flex-row justify-between items-center w-full h-full p-4 bg-white rounded-lg shadow-lg dark:bg-gray-800">
                 <div className="flex items-center space-x-4">
-                    <FileMenu queryText={queryText} currentGraph={currentGraph} onLoad={onLoad} />
+                    <FileMenu queryText={queryText} queryType={queryType} currentGraph={currentGraph} onLoad={onLoad} />
                     <PrimitivesMenu onInsertPrimitive={onInsertPrimitive} />
                     <HelpMenu />
                 </div>

--- a/motifstudio-web/src/app/FileMenu.tsx
+++ b/motifstudio-web/src/app/FileMenu.tsx
@@ -10,7 +10,7 @@ import { OpenDialog } from "./components/OpenDialog";
 import { DeleteConfirmDialog } from "./components/DeleteConfirmDialog";
 import { exportAsJSON } from "./utils/exportUtils";
 
-export function FileMenu({ queryText, currentGraph, onLoad }: FileMenuProps) {
+export function FileMenu({ queryText, queryType, currentGraph, onLoad }: FileMenuProps) {
     const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
     const [isOpenDialogOpen, setIsOpenDialogOpen] = useState(false);
     const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
@@ -26,6 +26,7 @@ export function FileMenu({ queryText, currentGraph, onLoad }: FileMenuProps) {
         onLoad({
             queryText: project.queryText,
             graph: project.graph,
+            queryType: project.queryType || "dotmotif",
         });
         setIsOpenDialogOpen(false);
     };
@@ -42,7 +43,7 @@ export function FileMenu({ queryText, currentGraph, onLoad }: FileMenuProps) {
     };
 
     const handleExport = () => {
-        exportAsJSON(queryText, currentGraph, true);
+        exportAsJSON(queryText, queryType, currentGraph, true);
     };
 
     return (
@@ -120,6 +121,7 @@ export function FileMenu({ queryText, currentGraph, onLoad }: FileMenuProps) {
                 isOpen={isSaveDialogOpen}
                 onClose={() => setIsSaveDialogOpen(false)}
                 queryText={queryText}
+                queryType={queryType}
                 currentGraph={currentGraph}
                 savedProjects={savedProjects}
                 onSave={handleSave}

--- a/motifstudio-web/src/app/GraphUpload.tsx
+++ b/motifstudio-web/src/app/GraphUpload.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { CloudArrowUpIcon, XMarkIcon, CheckCircleIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { BASE_URL, HostListing } from "./api";
 
@@ -20,6 +20,24 @@ export function GraphUpload({ onGraphUploaded }: GraphUploadProps) {
     const [uploadProgress, setUploadProgress] = useState<string>("");
     const [uploadedGraphs, setUploadedGraphs] = useState<UploadedGraph[]>([]);
     const [error, setError] = useState<string>("");
+    const successTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        const storedGraphs = localStorage.getItem("motifstudio_uploaded_graphs");
+        if (storedGraphs) {
+            try {
+                setUploadedGraphs(JSON.parse(storedGraphs));
+            } catch (err) {
+                console.error("Failed to parse stored graphs:", err);
+                localStorage.removeItem("motifstudio_uploaded_graphs");
+            }
+        }
+        return () => {
+            if (successTimer.current) {
+                clearTimeout(successTimer.current);
+            }
+        };
+    }, []);
 
     const handleDragOver = useCallback((e: React.DragEvent) => {
         e.preventDefault();
@@ -83,7 +101,10 @@ export function GraphUpload({ onGraphUploaded }: GraphUploadProps) {
                 const updated = [...existing, uploadedGraph];
                 localStorage.setItem("motifstudio_uploaded_graphs", JSON.stringify(updated));
 
-                setTimeout(() => setUploadProgress(""), 3000);
+                if (successTimer.current) {
+                    clearTimeout(successTimer.current);
+                }
+                successTimer.current = setTimeout(() => setUploadProgress(""), 3000);
             } else {
                 setError(result.error || "Upload failed");
             }
@@ -118,20 +139,6 @@ export function GraphUpload({ onGraphUploaded }: GraphUploadProps) {
             method: "DELETE",
         }).catch(console.error);
     };
-
-    // Load uploaded graphs from localStorage on component mount
-    useState(() => {
-        const storedGraphs = localStorage.getItem("motifstudio_uploaded_graphs");
-        if (storedGraphs) {
-            try {
-                const parsed = JSON.parse(storedGraphs);
-                setUploadedGraphs(parsed);
-            } catch (err) {
-                console.error("Failed to parse stored graphs:", err);
-                localStorage.removeItem("motifstudio_uploaded_graphs");
-            }
-        }
-    });
 
     return (
         <div className="space-y-4">

--- a/motifstudio-web/src/app/components/SaveDialog.tsx
+++ b/motifstudio-web/src/app/components/SaveDialog.tsx
@@ -5,7 +5,7 @@ import { Dialog } from "@headlessui/react";
 import { DocumentIcon } from "@heroicons/react/24/outline";
 import { SaveDialogProps, SavedProject } from "../types/fileMenu";
 
-export function SaveDialog({ isOpen, onClose, queryText, currentGraph, savedProjects, onSave }: SaveDialogProps) {
+export function SaveDialog({ isOpen, onClose, queryText, queryType, currentGraph, savedProjects, onSave }: SaveDialogProps) {
     const [saveName, setSaveName] = useState("");
     const [includeGraph, setIncludeGraph] = useState(true);
 
@@ -16,6 +16,7 @@ export function SaveDialog({ isOpen, onClose, queryText, currentGraph, savedProj
             id: "", // Will be set by the hook
             name: saveName.trim(),
             queryText,
+            queryType,
             graph: includeGraph ? currentGraph : undefined,
             timestamp: "", // Will be set by the hook
         };

--- a/motifstudio-web/src/app/hooks/useLocalStorage.ts
+++ b/motifstudio-web/src/app/hooks/useLocalStorage.ts
@@ -10,7 +10,13 @@ export function useLocalStorage() {
         // Load from localStorage on mount
         if (typeof window !== "undefined") {
             const saved = localStorage.getItem(STORAGE_KEY);
-            setSavedProjects(saved ? JSON.parse(saved) : []);
+            const projects = saved ? JSON.parse(saved) : [];
+            setSavedProjects(
+                projects.map((project: SavedProject) => ({
+                    ...project,
+                    queryType: project.queryType || "dotmotif",
+                }))
+            );
         }
     }, []);
 

--- a/motifstudio-web/src/app/page.tsx
+++ b/motifstudio-web/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Appbar } from "./Appbar";
 import { GraphForm } from "./GraphForm";
@@ -10,6 +10,7 @@ import { GraphStats } from "./GraphStats";
 import { ResultsWrapper } from "./ResultsWrapper";
 import { getQueryParams, updateQueryParams } from "./queryparams";
 import { MotifVisualizer } from "./MotifVisualizer";
+import { useDebounce } from "./useDebounce";
 
 /**
  * The main page of the application.
@@ -34,10 +35,17 @@ export default function Home() {
             : undefined
     );
     const [queryText, setQueryText] = useState(motif || "");
+    const debouncedQueryText = useDebounce(queryText, 500);
     const [queryType, setQueryType] = useState<"dotmotif" | "cypher">(
         (query_type as "dotmotif" | "cypher") || "dotmotif"
     );
     const [entities, setEntities] = useState<{ [key: string]: string }>({});
+
+    useEffect(() => {
+        if (typeof window !== "undefined") {
+            updateQueryParams({ motif: debouncedQueryText });
+        }
+    }, [debouncedQueryText]);
 
     function setSelectedGraph(graph: HostListing) {
         setCurrentGraph(graph);
@@ -48,9 +56,6 @@ export default function Home() {
 
     function updateMotifTest(value: string) {
         setQueryText(value);
-        if (typeof window !== "undefined") {
-            updateQueryParams({ motif: value });
-        }
     }
 
     function updateQueryType(type: "dotmotif" | "cypher") {
@@ -97,6 +102,7 @@ export default function Home() {
         <main className="flex min-h-screen flex-col items-center">
             <Appbar
                 queryText={queryText}
+                queryType={queryType}
                 currentGraph={currentGraph}
                 onLoad={handleLoad}
                 onInsertPrimitive={handleInsertPrimitive}
@@ -128,13 +134,7 @@ export default function Home() {
                     <GraphForm startValue={currentGraph} onGraphChange={setSelectedGraph} />
                 </div>
                 <div className="div flex w-full flex-col py-4 gap-4">
-                    {motif && queryType === "dotmotif" ? (
-                        <MotifVisualizer
-                            motifSource={motif}
-                            // graph={currentGraph}
-                            // entities={entities}
-                        />
-                    ) : null}
+                    {queryText && queryType === "dotmotif" ? <MotifVisualizer motifSource={queryText} /> : null}
                     {currentGraph ? <GraphStats graph={currentGraph} onAttributesLoaded={setEntities} /> : null}
                     {currentGraph ? (
                         <ResultsWrapper graph={currentGraph} query={queryText} queryType={queryType} />

--- a/motifstudio-web/src/app/queryparams.tsx
+++ b/motifstudio-web/src/app/queryparams.tsx
@@ -17,10 +17,10 @@ export function getQueryParams(): {
     const search = window.location.search;
     const params = new URLSearchParams(search);
     return {
-        host_id: decodeURIComponent(params.get("host_id") || ""),
-        host_name: decodeURIComponent(params.get("host_name") || ""),
-        motif: decodeURIComponent(params.get("motif") || ""),
-        query_type: decodeURIComponent(params.get("query_type") || "dotmotif"),
+        host_id: params.get("host_id") || "",
+        host_name: params.get("host_name") || "",
+        motif: params.get("motif") || "",
+        query_type: params.get("query_type") || "dotmotif",
     };
 }
 
@@ -39,8 +39,12 @@ export function getQueryParams(): {
 export function updateQueryParams(params: { [key: string]: string }) {
     const search = new URLSearchParams(window.location.search);
     for (const key in params) {
-        // URL-encode each value:
-        search.set(key, encodeURIComponent(params[key]));
+        if (params[key]) {
+            search.set(key, params[key]);
+        } else {
+            search.delete(key);
+        }
     }
-    window.history.replaceState({}, "", `${window.location.pathname}?${search}`);
+    const query = search.toString();
+    window.history.replaceState({}, "", `${window.location.pathname}${query ? `?${query}` : ""}`);
 }

--- a/motifstudio-web/src/app/types/fileMenu.ts
+++ b/motifstudio-web/src/app/types/fileMenu.ts
@@ -4,6 +4,7 @@ export interface SavedProject {
     id: string;
     name: string;
     queryText: string;
+    queryType: "dotmotif" | "cypher";
     graph?: HostListing;
     timestamp: string;
 }
@@ -11,7 +12,8 @@ export interface SavedProject {
 export interface FileMenuProps {
     queryText: string;
     currentGraph?: HostListing;
-    onLoad: (data: { queryText: string; graph?: HostListing }) => void;
+    queryType: "dotmotif" | "cypher";
+    onLoad: (data: { queryText: string; graph?: HostListing; queryType?: "dotmotif" | "cypher" }) => void;
 }
 
 export interface SaveDialogProps {
@@ -19,6 +21,7 @@ export interface SaveDialogProps {
     onClose: () => void;
     queryText: string;
     currentGraph?: HostListing;
+    queryType: "dotmotif" | "cypher";
     savedProjects: SavedProject[];
     onSave: (project: SavedProject) => void;
 }

--- a/motifstudio-web/src/app/utils/exportUtils.ts
+++ b/motifstudio-web/src/app/utils/exportUtils.ts
@@ -1,8 +1,14 @@
 import { HostListing } from "../api";
 
-export function exportAsJSON(queryText: string, currentGraph?: HostListing, includeGraph: boolean = true) {
+export function exportAsJSON(
+    queryText: string,
+    queryType: "dotmotif" | "cypher",
+    currentGraph?: HostListing,
+    includeGraph: boolean = true
+) {
     const exportData = {
         queryText,
+        queryType,
         graph: includeGraph ? currentGraph : undefined,
         exportedAt: new Date().toISOString(),
     };


### PR DESCRIPTION
- Debounce editor state updates to the URL and remove redundant encoding
- Drive motif visualization from current editor contents
- Persist query language in saved and exported projects
- Migrate existing saved projects to DotMotif explicitly
- Restore uploads in an effect and clean up success timers